### PR TITLE
Fixed compile error

### DIFF
--- a/src/get_settings.cpp
+++ b/src/get_settings.cpp
@@ -85,8 +85,8 @@ bool initializeSettings()
 					if (!(std::isnan(capture_setting.fov_degrees)))
 					{
 						std::cout << "image_type:" << capture_setting.image_type << std::endl;
-						std::cout << "fov_degrees:" << capture_setting.fov_degrees << std::endl;
-						std::cout << "publish_to_ros:" << capture_setting.publish_to_ros << std::endl;
+						std::cout << "fov_degrees:" << capture_setting.fov_degrees << std::endl;						
+						//std::cout << "publish_to_ros:" << capture_setting.publish_to_ros << std::endl;
 					}
 
 				}


### PR DESCRIPTION
On my system I get an error on line 89, with the message:

`publish_to_ros` is not a member of `capture_setting`

Commenting out that line fixes the issue.

I am able to compile on Linux 64-bit, with latest AirSim master branch and UE4 4.18 as specified.